### PR TITLE
Add lookup examples

### DIFF
--- a/content.js
+++ b/content.js
@@ -7,6 +7,14 @@ Alice.updateContent({
   welcome: {
       title: "My Awesome Looking Glass",
       tagline: "powered by Alice, your friendly BIRD||GoGBP||OpenBGPd Looking Glass"
+  },
+  lookup: {
+    examples: [
+      ["asn", "AS64512"],
+      ["community", 64512, 1000, 1],
+      ["community", 65520, 0],
+      ["q", "Example"],
+    ]
   }
 });
 


### PR DESCRIPTION
Add a theme example to demonstrate how to show some Alice search query example buttons.